### PR TITLE
Handle missing Sophus version metadata

### DIFF
--- a/Thirdparty/Sophus/CMakeLists.txt
+++ b/Thirdparty/Sophus/CMakeLists.txt
@@ -1,6 +1,23 @@
 cmake_minimum_required(VERSION 3.24)
 
-file(READ "SOPHUS_VERSION" SOPHUS_VERSION)
+set(SOPHUS_VERSION "" CACHE STRING "Sophus version string")
+set(_sophus_version "${SOPHUS_VERSION}")
+if(NOT _sophus_version)
+  set(_sophus_version_file "${CMAKE_CURRENT_SOURCE_DIR}/SOPHUS_VERSION")
+  if(EXISTS "${_sophus_version_file}")
+    file(READ "${_sophus_version_file}" _sophus_version_contents)
+    string(STRIP "${_sophus_version_contents}" _sophus_version)
+  else()
+    set(_sophus_version "1.0.0")
+    message(
+      WARNING
+        "SOPHUS_VERSION file not found; using fallback version ${_sophus_version}."
+    )
+  endif()
+  set(SOPHUS_VERSION "${_sophus_version}" CACHE STRING "Sophus version string" FORCE)
+endif()
+unset(_sophus_version_contents)
+unset(_sophus_version_file)
 project(Sophus VERSION ${SOPHUS_VERSION})
 
 include(CMakePackageConfigHelpers)

--- a/Thirdparty/Sophus/examples/CMakeLists.txt
+++ b/Thirdparty/Sophus/examples/CMakeLists.txt
@@ -2,8 +2,19 @@ cmake_minimum_required(VERSION 3.24)
 
 project(SophusExample)
 
-file(READ "../SOPHUS_VERSION" SOPHUS_VERSION)
-find_package(Sophus ${SOPHUS_VERSION} REQUIRED)
+set(_sophus_version_requirement "${SOPHUS_VERSION}")
+if(NOT _sophus_version_requirement)
+  set(_sophus_version_file "${CMAKE_CURRENT_LIST_DIR}/../SOPHUS_VERSION")
+  if(EXISTS "${_sophus_version_file}")
+    file(READ "${_sophus_version_file}" _sophus_version_contents)
+    string(STRIP "${_sophus_version_contents}" _sophus_version_requirement)
+  else()
+    set(_sophus_version_requirement "1.0.0")
+  endif()
+endif()
+unset(_sophus_version_contents)
+unset(_sophus_version_file)
+find_package(Sophus ${_sophus_version_requirement} REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 
 # Release by default Turn on Debug with "-DCMAKE_BUILD_TYPE=Debug"

--- a/Thirdparty/Sophus/setup.py
+++ b/Thirdparty/Sophus/setup.py
@@ -8,6 +8,19 @@ from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_VERSION = "1.0.0"
+
+
+def read_version():
+    version_file = Path(__file__).with_name("SOPHUS_VERSION")
+    if version_file.exists():
+        return version_file.read_text().strip()
+
+    env_version = os.environ.get("SOPHUS_VERSION")
+    if env_version:
+        return env_version
+
+    return DEFAULT_VERSION
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
@@ -141,7 +154,7 @@ def main():
     # logic and declaration, and simpler if you include description/version in a file.
     setup(
         name="sophus_pybind",
-        version=Path("SOPHUS_VERSION").read_text(),
+        version=read_version(),
         description="Sophus python API",
         long_description="Python API for sophus library",
         url="https://github.com/strasdat/sophus",


### PR DESCRIPTION
## Summary
- make Sophus' CMake build tolerant to a missing SOPHUS_VERSION file by providing a configurable fallback value
- allow the sample projects to reuse the computed version without assuming the metadata file exists
- teach setup.py to derive the package version from the metadata file when present and fall back to a default or environment override otherwise

## Testing
- cmake -S Thirdparty/Sophus -B build_sophus *(fails: Eigen3 dependency not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ef804af0832ea9183847aba6c6f7